### PR TITLE
Added override-able getIp method

### DIFF
--- a/UnitPay.php
+++ b/UnitPay.php
@@ -67,6 +67,16 @@ class UnitPay
     }
 
     /**
+     * Return IP address
+     *
+     * @return string
+     */
+    protected function getIp()
+    {
+        return $_SERVER['REMOTE_ADDR'];
+    }
+
+    /**
      * Get URL for pay through the form
      *
      * @param $publicKey
@@ -145,7 +155,7 @@ class UnitPay
      */
     public function checkHandlerRequest()
     {
-        $ip = $_SERVER['REMOTE_ADDR'];
+        $ip = $this->getIp();
         if (!isset($_GET['method'])) {
             throw new InvalidArgumentException('Method is null');
         }


### PR DESCRIPTION
When using services such as CloudFlare, the IP from `$_SERVER['REMOTE_ADDR']` is actually CloudFlare's ip, the real IP is stored in `$_SERVER['HTTP_CF_CONNECTING_IP']`.

Using an override-able method the users can extend the base UnitPay class and implement their own `getIp` method, not needing to change the base class.
