### PR TITLE
fix array_merge exception - 'Argument #1 is not array'

### DIFF
--- a/UnitPay.php
+++ b/UnitPay.php
@@ -94,7 +94,7 @@ class UnitPay
 
     private $secretKey;
 
-    private $params;
+    private $params = array();
 
     const API_URL  = 'https://unitpay.ru/api';
     const FORM_URL = 'https://unitpay.ru/pay/';


### PR DESCRIPTION
С недавних пор при попытке оплатить услугу посредством Unitpay стала появляться ошибка у клиента:

![68747470733a2f2f6d6f6e6f736e61702e636f6d2f66696c652f695243366f6a4f39424b7a30704767477850705733766138313948514c512e706e67](https://user-images.githubusercontent.com/2945846/29357473-59a6b928-8280-11e7-9171-81787a3ba352.png)

При отладке обнаружил следующую ошибку:

![q9c79](https://user-images.githubusercontent.com/2945846/29357504-705a981a-8280-11e7-8e3c-22b9cebcb3ec.png)

Полагаю, виной этому послужил последний pull request https://github.com/unitpay/php-sdk/pull/9 , где не проработан случай, когда не требуются определять новые доп. параметры, как в нашем случае.

Поэтому предлагаю микро исправление для случаев, когда не задано ни одного параметра из нового функционала:

```
$unitPay
    ->setBackUrl('http://domain.com')
    ->setCustomerEmail('customer@domain.com')
    ->setCustomerPhone('79001235555')
    ->setCashItems(array(
       new CashItem($itemName, 1, $orderSum) 
    ));
```

